### PR TITLE
Use computed name instead of route name

### DIFF
--- a/resources/assets/js/backend/containers/Full.vue
+++ b/resources/assets/js/backend/containers/Full.vue
@@ -12,7 +12,7 @@
         </b-alert>
         <breadcrumb :list="list"></breadcrumb>
         <b-container fluid>
-          <router-view :key="$route.name"></router-view>
+          <router-view :key="name"></router-view>
         </b-container>
       </main>
       <AppAside></AppAside>


### PR DESCRIPTION
I guess you made `name()` for this reason otherwise i don't see why there is `name()` in `computed` object