### PR TITLE
Fix deprecation warning from vue b-form-group

### DIFF
--- a/resources/js/backend/views/FormSettingForm.vue
+++ b/resources/js/backend/views/FormSettingForm.vue
@@ -14,8 +14,7 @@
             <b-form-group
               :label="$t('validation.attributes.form_type')"
               label-for="name"
-              horizontal
-              :label-cols="3"
+              label-cols-sm="3"
             >
               <select
                 id="name"
@@ -40,8 +39,7 @@
               :description="
                 $t('labels.backend.form_settings.descriptions.recipients')
               "
-              horizontal
-              :label-cols="3"
+              label-cols-sm="3"
               :feedback="feedback('recipients')"
             >
               <b-form-textarea
@@ -61,8 +59,7 @@
               :description="
                 $t('labels.backend.form_settings.descriptions.message')
               "
-              horizontal
-              :label-cols="3"
+              label-cols-sm="3"
               :feedback="feedback('message')"
             >
               <b-form-textarea

--- a/resources/js/backend/views/MetaForm.vue
+++ b/resources/js/backend/views/MetaForm.vue
@@ -30,8 +30,7 @@
               <b-form-group
                 :label="$t('validation.attributes.route')"
                 label-for="route"
-                horizontal
-                :label-cols="3"
+                label-cols-sm="3"
                 :feedback="feedback('route')"
                 :state="state('route')"
               >
@@ -53,8 +52,7 @@
             <b-form-group
               :label="$t('validation.attributes.title')"
               label-for="title"
-              horizontal
-              :label-cols="3"
+              label-cols-sm="3"
               :feedback="feedback('title')"
             >
               <b-form-input
@@ -69,8 +67,7 @@
             <b-form-group
               :label="$t('validation.attributes.description')"
               label-for="description"
-              horizontal
-              :label-cols="3"
+              label-cols-sm="3"
               :feedback="feedback('description')"
             >
               <b-form-textarea

--- a/resources/js/backend/views/PostForm.vue
+++ b/resources/js/backend/views/PostForm.vue
@@ -14,8 +14,7 @@
             <b-form-group
               :label="$t('validation.attributes.title')"
               label-for="title"
-              horizontal
-              :label-cols="2"
+              label-cols-sm="2"
               :feedback="feedback('title')"
             >
               <b-form-input
@@ -31,8 +30,7 @@
             <b-form-group
               :label="$t('validation.attributes.summary')"
               label-for="summary"
-              horizontal
-              :label-cols="2"
+              label-cols-sm="2"
               :feedback="feedback('summary')"
             >
               <b-form-textarea
@@ -48,8 +46,7 @@
             <b-form-group
               :label="$t('validation.attributes.body')"
               label-for="body"
-              horizontal
-              :label-cols="2"
+              label-cols-sm="2"
             >
               <p-richtexteditor
                 name="body"
@@ -60,8 +57,7 @@
             <b-form-group
               :label="$t('validation.attributes.tags')"
               label-for="tags"
-              horizontal
-              :label-cols="2"
+              label-cols-sm="2"
             >
               <v-select
                 id="tags"
@@ -79,8 +75,7 @@
             <b-form-group
               :label="$t('validation.attributes.image')"
               label-for="featured_image"
-              horizontal
-              :label-cols="2"
+              label-cols-sm="2"
               :feedback="feedback('featured_image')"
             >
               <div class="media">
@@ -211,8 +206,7 @@
                     v-if="this.$app.user.can('publish posts')"
                     :label="$t('validation.attributes.published_at')"
                     label-for="published_at"
-                    horizontal
-                    :label-cols="3"
+                    label-cols-sm="3"
                   >
                     <b-input-group>
                       <p-datetimepicker
@@ -236,8 +230,7 @@
                     v-if="this.$app.user.can('publish posts')"
                     :label="$t('validation.attributes.unpublished_at')"
                     label-for="unpublished_at"
-                    horizontal
-                    :label-cols="3"
+                    label-cols-sm="3"
                   >
                     <b-input-group>
                       <p-datetimepicker
@@ -303,8 +296,7 @@
                     :description="
                       $t('labels.backend.posts.descriptions.meta_title')
                     "
-                    horizontal
-                    :label-cols="3"
+                    label-cols-sm="3"
                   >
                     <b-form-input
                       id="meta_title"
@@ -322,8 +314,7 @@
                     :description="
                       $t('labels.backend.posts.descriptions.meta_description')
                     "
-                    horizontal
-                    :label-cols="3"
+                    label-cols-sm="3"
                   >
                     <b-form-textarea
                       id="meta_description"

--- a/resources/js/backend/views/RedirectionForm.vue
+++ b/resources/js/backend/views/RedirectionForm.vue
@@ -15,8 +15,7 @@
             <b-form-group
               :label="$t('validation.attributes.source_path')"
               label-for="source"
-              horizontal
-              :label-cols="3"
+              label-cols-sm="3"
               :feedback="feedback('source')"
             >
               <b-form-input
@@ -44,8 +43,7 @@
             <b-form-group
               :label="$t('validation.attributes.target_path')"
               label-for="target"
-              horizontal
-              :label-cols="3"
+              label-cols-sm="3"
               :feedback="feedback('target')"
             >
               <b-form-input
@@ -61,8 +59,7 @@
             <b-form-group
               :label="$t('validation.attributes.redirect_type')"
               label-for="type"
-              horizontal
-              :label-cols="3"
+              label-cols-sm="3"
             >
               <b-form-radio-group
                 stacked

--- a/resources/js/backend/views/RoleForm.vue
+++ b/resources/js/backend/views/RoleForm.vue
@@ -15,8 +15,7 @@
             <b-form-group
               :label="$t('validation.attributes.name')"
               label-for="name"
-              horizontal
-              :label-cols="2"
+              label-cols-sm="2"
             >
               <b-row>
                 <b-col md="6">
@@ -36,8 +35,7 @@
             <b-form-group
               :label="$t('validation.attributes.display_name')"
               label-for="display_name"
-              horizontal
-              :label-cols="2"
+              label-cols-sm="2"
             >
               <b-row>
                 <b-col md="6">
@@ -59,8 +57,7 @@
             <b-form-group
               :label="$t('validation.attributes.description')"
               label-for="description"
-              horizontal
-              :label-cols="2"
+              label-cols-sm="2"
               :feedback="feedback('description')"
             >
               <b-form-input
@@ -75,8 +72,7 @@
             <b-form-group
               :label="$t('validation.attributes.order')"
               label-for="order"
-              horizontal
-              :label-cols="2"
+              label-cols-sm="2"
             >
               <b-row>
                 <b-col md="3">

--- a/resources/js/backend/views/UserForm.vue
+++ b/resources/js/backend/views/UserForm.vue
@@ -15,8 +15,7 @@
             <b-form-group
               :label="$t('validation.attributes.name')"
               label-for="name"
-              horizontal
-              :label-cols="3"
+              label-cols-sm="3"
               :feedback="feedback('name')"
             >
               <b-form-input
@@ -32,8 +31,7 @@
             <b-form-group
               :label="$t('validation.attributes.email')"
               label-for="email"
-              horizontal
-              :label-cols="3"
+              label-cols-sm="3"
               :feedback="feedback('email')"
             >
               <b-form-input
@@ -62,8 +60,7 @@
             <b-form-group
               :label="$t('validation.attributes.password')"
               label-for="password"
-              horizontal
-              :label-cols="3"
+              label-cols-sm="3"
               :feedback="feedback('password')"
             >
               <b-form-input
@@ -79,8 +76,7 @@
             <b-form-group
               :label="$t('validation.attributes.password_confirmation')"
               label-for="password_confirmation"
-              horizontal
-              :label-cols="3"
+              label-cols-sm="3"
               :feedback="feedback('password_confirmation')"
             >
               <b-form-input
@@ -96,8 +92,7 @@
             <b-form-group
               :label="$t('validation.attributes.roles')"
               label-for="roles"
-              horizontal
-              :label-cols="3"
+              label-cols-sm="3"
             >
               <b-form-checkbox-group
                 stacked


### PR DESCRIPTION
The props horizontal and breakpoint have been deprecated in favour of using the label-cols and label-cols-{breakpoint} props.